### PR TITLE
Fix to default torch device and tqdm_notebook

### DIFF
--- a/dlnlputils/pipeline.py
+++ b/dlnlputils/pipeline.py
@@ -41,7 +41,7 @@ def print_grad_stats(model):
 
 def train_eval_loop(model, train_dataset, val_dataset, criterion,
                     lr=1e-4, epoch_n=10, batch_size=32,
-                    device='cuda', early_stopping_patience=10, l2_reg_alpha=0,
+                    device=None, early_stopping_patience=10, l2_reg_alpha=0,
                     max_batches_per_epoch_train=10000,
                     max_batches_per_epoch_val=1000,
                     data_loader_ctor=DataLoader,
@@ -70,6 +70,8 @@ def train_eval_loop(model, train_dataset, val_dataset, criterion,
         - среднее значение функции потерь на валидации на лучшей эпохе
         - лучшая модель
     """
+    if device is None:
+        device = 'cuda' if torch.cuda.is_available() else 'cpu'
     device = torch.device(device)
     model.to(device)
 
@@ -170,7 +172,7 @@ def train_eval_loop(model, train_dataset, val_dataset, criterion,
     return best_val_loss, best_model
 
 
-def predict_with_model(model, dataset, device='cuda', batch_size=32, num_workers=0, return_labels=False):
+def predict_with_model(model, dataset, device=None, batch_size=32, num_workers=0, return_labels=False):
     """
     :param model: torch.nn.Module - обученная модель
     :param dataset: torch.utils.data.Dataset - данные для применения модели
@@ -178,6 +180,8 @@ def predict_with_model(model, dataset, device='cuda', batch_size=32, num_workers
     :param batch_size: количество примеров, обрабатываемых моделью за одну итерацию
     :return: numpy.array размерности len(dataset) x *
     """
+    if device is None:
+        device = 'cuda' if torch.cuda.is_available() else 'cpu'
     results_by_batch = []
 
     device = torch.device(device)

--- a/dlnlputils/pipeline.py
+++ b/dlnlputils/pipeline.py
@@ -192,7 +192,7 @@ def predict_with_model(model, dataset, device=None, batch_size=32, num_workers=0
     labels = []
     with torch.no_grad():
         import tqdm
-        for batch_x, batch_y in tqdm.tqdm_notebook(dataloader, total=len(dataset)/batch_size):
+        for batch_x, batch_y in tqdm.tqdm(dataloader, total=len(dataset)/batch_size):
             batch_x = copy_data_to_device(batch_x, device)
 
             if return_labels:


### PR DESCRIPTION
First commit allows default device in `train_eval_loop` and `predict_with_model` to be CPU, if no CUDA was detected.

Second commit fixes the following error, which occurs with `tqdm==4.36.1`, `jupyterlab==1.1.4` and `tqdm.tqdm_notebook(...)` call:

`ImportError: IntProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html`