### PR TITLE
поправил ссылку в третьем задании

### DIFF
--- a/task3_cnn_postag.ipynb
+++ b/task3_cnn_postag.ipynb
@@ -92,7 +92,7 @@
    "outputs": [],
    "source": [
     "# Если Вы запускаете ноутбук на colab или kaggle, добавьте в начало пути ./stepik-dl-nlp\n",
-    "!wget -O ./datasets/ru_syntagrus-ud-train.conllu https://raw.githubusercontent.com/UniversalDependencies/UD_Russian-SynTagRus/master/ru_syntagrus-ud-train.conllu\n",
+    "!wget -O ./datasets/ru_syntagrus-ud-train.conllu https://raw.githubusercontent.com/UniversalDependencies/UD_Russian-SynTagRus/master/ru_syntagrus-ud-train-a.conllu\n",
     "!wget -O ./datasets/ru_syntagrus-ud-dev.conllu https://raw.githubusercontent.com/UniversalDependencies/UD_Russian-SynTagRus/master/ru_syntagrus-ud-dev.conllu"
    ]
   },


### PR DESCRIPTION
Корпус SynTagRus теперь разбит на несколько файлов с новыми именами. Старые пути перестали работать, но если вместо старого файла указать первую новую часть, то все чинится